### PR TITLE
RT ticket 25274

### DIFF
--- a/lib/Math/BigInt/Calc.pm
+++ b/lib/Math/BigInt/Calc.pm
@@ -270,20 +270,24 @@ sub _str
   $ret;
   }                                                                             
 
-sub _num
-  {
-  # Make a number (scalar int/float) from a BigInt object 
-  my $x = $_[1];
+sub _num {
+    # Make a number (scalar int/float) from a BigInt object.
+    my $x = $_[1];
 
-  return 0+$x->[0] if scalar @$x == 1;  # below $BASE
-  my $fac = 1;
-  my $num = 0;
-  foreach (@$x)
-    {
-    $num += $fac*$_; $fac *= $BASE;
+    return 0 + $x->[0] if scalar @$x == 1;      # below $BASE
+
+    # Start with the most significant element and work towards the least
+    # significant element. This has two advantages: 1) the number is not
+    # converted to a floating point format too early, and 2) we completely
+    # avoid multiplying "inf" with "0", giving "nan".
+
+    my $num = 0;
+    for (my $i = $#$x ; $i >= 0 ; --$i) {
+        $num *= $BASE;
+        $num += $x -> [$i];
     }
-  $num; 
-  }
+    return $num;
+}
 
 ##############################################################################
 # actual math code

--- a/t/bare_mbi.t
+++ b/t/bare_mbi.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl -w
 
 use strict;
-use Test::More tests => 3285;
+use Test::More tests => 3287;
 
 BEGIN { unshift @INC, 't'; }
 

--- a/t/bigintpm.inc
+++ b/t/bigintpm.inc
@@ -1182,6 +1182,8 @@ numifyabc:NaN
 -5:-5
 100:100
 -100:-100
+1e999999:inf
+-1e999999:-inf
 &bneg
 bnegNaN:NaN
 +inf:-inf

--- a/t/bigintpm.t
+++ b/t/bigintpm.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl -w
 
 use strict;
-use Test::More tests => 3285 + 6;
+use Test::More tests => 3287 + 6;
 
 use Math::BigInt lib => 'Calc';
 

--- a/t/sub_mbi.t
+++ b/t/sub_mbi.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl -w
 
 use strict;
-use Test::More tests => 3285
+use Test::More tests => 3287
     + 5;	# +5 own tests
 
 BEGIN { unshift @INC, 't'; }


### PR DESCRIPTION
Fixes the Math::BigInt::Calc-related stuff of RT ticket 25274. There are similar problems with other libraries, at least Math::BigInt::FastCalc and Math::BigInt::GMP, but those aren't covered in this commit, as they belong to other distributions.
